### PR TITLE
Clarify PyTorch and CUDA requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Pytorch implementation for high-resolution (e.g., 2048x1024) photorealistic vide
 - Linux or macOS
 - Python 3
 - NVIDIA GPU + CUDA cuDNN
-- PyTorch 0.4
-
+- PyTorch 0.4 or 0.4.1
+  - If using PyTorch 0.4, CUDA 9.0 must be used
 
 ## Getting Started
 ### Installation

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Pytorch implementation for high-resolution (e.g., 2048x1024) photorealistic vide
 - Linux or macOS
 - Python 3
 - NVIDIA GPU + CUDA cuDNN
+  - CUDA 9.0 if using PyTorch 0.4
+  - CUDA 9.2 if using PyTorch 0.4.1
 - PyTorch 0.4 or 0.4.1
-  - If using PyTorch 0.4, CUDA 9.0 must be used
 
 ## Getting Started
 ### Installation


### PR DESCRIPTION
Minor README update after some pain on my end trying to set it up.

If you're using PyTorch 0.4, you must use CUDA 9.0 or you'll get an error like the following if you're using CUDA 9.2:
```
undefined symbol: __cudaPopCallConfiguration
```

in `models/flownet2_pytorch/networks/resample2d_package/_ext/resample2d/_resample2d.so`